### PR TITLE
Update to roving exhibition date in MOE HC 

### DIFF
--- a/_whats-on/Upcoming Events/Seeds of Change: School Campaigns from the 1950s till the Present.md
+++ b/_whats-on/Upcoming Events/Seeds of Change: School Campaigns from the 1950s till the Present.md
@@ -70,7 +70,7 @@ and beliefs, and our vision for Singapore as we journey ahead together.</p>
 </p>
 </li>
 <li>
-<p><strong>MOE Heritage Centre: 5 May - 31 Dec 2026</strong>
+<p><strong>MOE Heritage Centre: 6 May - 31 Dec 2026</strong>
 </p>
 </li>
 </ul>

--- a/_whats-on/Upcoming Events/Seeds of Change: School Campaigns from the 1950s till the Present.md
+++ b/_whats-on/Upcoming Events/Seeds of Change: School Campaigns from the 1950s till the Present.md
@@ -103,7 +103,8 @@ seeds of inspiration for the next generation.   &nbsp;&nbsp;</p>
 <p>SAFRA Jurong – 18 Mar 2026, 2.00pm <sub>[PAST EVENT]&nbsp;</sub> &nbsp;</p>
 </li>
 <li>
-<p>Bishan Library – 18 Apr 2026, 2.00pm [<em>OPEN FOR BOOKING</em>] &nbsp; &nbsp;&nbsp;</p>
+<p>Bishan Library – 18 Apr 2026, 2.00pm <sub>[PAST EVENT]</sub>
+</p>
 </li>
 <li>
 <p>MOE Heritage Centre – Sep, Dec 2026    &nbsp;&nbsp;</p>


### PR DESCRIPTION
To chang the original start date of roving exhibition in MOE Heritage Centre: 5 May - 31 Dec 2026 to 6 May - 31 Dec 2026

