### PR TITLE
Gallery closure dates (Jul to Sep)

### DIFF
--- a/_visit/Plan Your Visit.md
+++ b/_visit/Plan Your Visit.md
@@ -19,10 +19,11 @@ Closed on weekends and public holidays.
 
 
 
-* 7 April 2026 |  2pm - 5pm (last entry
+
+* 30 June 2026 | Full day closure
+* 7 July 2026 | 2pm - 5pm (last entry
 4.30pm)
-* 21 April 2026 | 2pm - 5pm (last entry
-4.30pm)
+* 18 August 2026 | Full day closure
 
 ### **Contact Details**
 Drop us an email at [moe_heritage_centre@moe.gov.sg](mailto:moe_heritage_centre@moe.gov.sg) 

--- a/_visit/Plan Your Visit.md
+++ b/_visit/Plan Your Visit.md
@@ -24,6 +24,8 @@ Closed on weekends and public holidays.
 * 7 July 2026 | 2pm - 5pm (last entry
 4.30pm)
 * 18 August 2026 | Full day closure
+* 17 September 2026 | 2pm - 5pm (last entry
+4.30pm)
 
 ### **Contact Details**
 Drop us an email at [moe_heritage_centre@moe.gov.sg](mailto:moe_heritage_centre@moe.gov.sg) 


### PR DESCRIPTION
Following up on my email yesterday (23/06) to the team on gallery closure dates, I'm putting up a gallery closure announcement on the website as follows: 

* 30 June 2026 | Full day closure
* 7 July 2026 | 2pm - 5pm (last entry 4.30pm)
* 18 August 2026 | Full day closure
* 17 September 2026 | 2pm - 5pm (last entry 4.30pm)